### PR TITLE
Handle invalid NiN in se.py validator

### DIFF
--- a/nin/validators/se.py
+++ b/nin/validators/se.py
@@ -8,15 +8,20 @@ from .generic import calculate_age
 
 break_year = 2000
 
+
 def is_valid(nin):
     nin = sanitize(nin)
     if len(nin) not in (10, 11, 12, 13):
         return False
 
-    nin = humanize(nin)
+    try:
+        nin = humanize(nin)
+    except ValueError:
+        return False
 
     return True
     # Not implemented yet
+
 
 def get_age(nin):
     nin = sanitize(nin)
@@ -26,14 +31,16 @@ def get_age(nin):
     nin = humanize(nin)
 
     try:
-        born = date(year=int(nin['year']), day=int(nin['day']), month=int(nin['month']))
+        born = date(year=int(nin['year']), day=int(
+            nin['day']), month=int(nin['month']))
     except Exception:
         return None
 
     return calculate_age(born)
 
+
 def humanize(nin):
-    if not '-' in nin and not '+' in nin:
+    if '-' not in nin and '+' not in nin:
         if len(nin) == 10:
             nin = '-'.join([nin[:6], nin[6:]])
         elif len(nin) == 12:
@@ -55,6 +62,7 @@ def humanize(nin):
     year = year_prefix + year
 
     return locals()
+
 
 def sanitize(nin):
     return nin.strip()


### PR DESCRIPTION
The se.py validator will fail with a ValueError exception if you pass something like this to it: ¨410321-9202
Exception thrown:
if int(year) <= (date.today().year - break_year) and century == '-':
ValueError: invalid literal for int() with base 10: '¨4'

Handling this with an try/except seems to make sense as the NiN is clearly not valid here.
